### PR TITLE
Add JSXHint handler

### DIFF
--- a/farcy/__init__.py
+++ b/farcy/__init__.py
@@ -184,7 +184,8 @@ class Farcy(object):
     def _load_handlers(self):
         from . import handlers
         self._ext_to_handler = defaultdict(list)
-        for handler in (handlers.Flake8, handlers.Pep257, handlers.Rubocop):
+        for handler in (handlers.Flake8, handlers.Pep257, handlers.Rubocop,
+                        handlers.JSXHint):
             try:
                 handler_inst = handler()
             except HandlerException:

--- a/farcy/handlers.py
+++ b/farcy/handlers.py
@@ -204,6 +204,7 @@ class JSXHint(ExtHandler):
         return retval
 
     def assert_usable(self):
+        """Raise HandlerException if the handler is not ready for use."""
         try:
             version = (check_output([self.BINARY, '--version'], stderr=STDOUT)
                        .decode('utf-8'))
@@ -218,4 +219,5 @@ class JSXHint(ExtHandler):
         self.verify_version(self.version_callback(version))
 
     def version_callback(self, version):
+        """Return a parsed version string for the binary version."""
         return version.split(' ')[1][1:]


### PR DESCRIPTION
This adds a jsxhint handler for Farcy.

I don't want to merge it because it feels like a hack:

 * I had to overwrite `_process` because I wanted to provide command line arguments. Duplicating code in the process.
 * I had to overwrite `assert_usable` because jsxhint outputs the version string to `STDERR`.
 * `version_callback` does no error checking

I wonder if I should restructure `ExtHandler` and the other handlers to allow certain pieces of code to be more easily reused or stay with the code duplication.