### PR TITLE
Add support for linter configuration files

### DIFF
--- a/farcy/__init__.py
+++ b/farcy/__init__.py
@@ -31,7 +31,7 @@ import tempfile
 import time
 from .const import (
     NUMBER_RE, __version__, VERSION_STR, PR_ISSUE_COMMENT_FORMAT,
-    COMMIT_STATUS_FORMAT, FARCY_COMMENT_START)
+    COMMIT_STATUS_FORMAT, FARCY_COMMENT_START, CONFIG_DIR)
 from .exceptions import FarcyException, HandlerException
 from .helpers import UTC, issues_by_line, subtract_issues_by_line
 
@@ -82,7 +82,7 @@ class Farcy(object):
     @staticmethod
     def get_session():
         """Fetch and/or load API authorization token for GITHUB."""
-        credential_file = os.path.expanduser('~/.config/farcy')
+        credential_file = os.path.join(CONFIG_DIR, 'github_auth')
         if os.path.isfile(credential_file):
             with open(credential_file) as fd:
                 token = fd.readline().strip()

--- a/farcy/const.py
+++ b/farcy/const.py
@@ -1,4 +1,5 @@
 """Constants used throughout Farcy."""
+import os
 import re
 
 __version__ = '0.1b'
@@ -9,4 +10,6 @@ MD_VERSION_STR = ('[{0}](https://github.com/appfolio/farcy)'
 PR_ISSUE_COMMENT_FORMAT = '_{0}_ {{0}}'.format(MD_VERSION_STR)
 COMMIT_STATUS_FORMAT = '{0} {{0}}'.format(VERSION_STR)
 
-FARCY_COMMENT_START = '_{}_'.format(MD_VERSION_STR)
+FARCY_COMMENT_START = '_{0}_'.format(MD_VERSION_STR)
+
+CONFIG_DIR = os.path.expanduser('~/.config/farcy')

--- a/farcy/handlers.py
+++ b/farcy/handlers.py
@@ -2,9 +2,9 @@
 
 from __future__ import print_function
 from collections import defaultdict
-from .const import CONFIG_DIR
 from subprocess import CalledProcessError, STDOUT, check_output
 from update_checker import parse_version
+from .const import CONFIG_DIR
 from .exceptions import HandlerException, HandlerNotReady
 import json
 import logging


### PR DESCRIPTION
This pull request adds support for configuration files for your linters.

As discussed last week, Farcy will look for configuration files in the folder `~/.config/farcy/handler_{name}.conf`.