### PR TITLE
No longer fail when parsing patch with no newline at end msg

### DIFF
--- a/farcy/__init__.py
+++ b/farcy/__init__.py
@@ -38,7 +38,7 @@ from .const import (
     __version__, VERSION_STR, PR_ISSUE_COMMENT_FORMAT,
     COMMIT_STATUS_FORMAT, FARCY_COMMENT_START, CONFIG_DIR)
 from .exceptions import FarcyException, HandlerException
-from .helpers import UTC, issues_by_line, subtract_issues_by_line, added_lines
+from .helpers import added_lines, UTC, issues_by_line, subtract_issues_by_line
 
 """
 TODO:

--- a/farcy/helpers.py
+++ b/farcy/helpers.py
@@ -3,9 +3,30 @@
 
 from collections import defaultdict
 from datetime import timedelta, tzinfo
-from .const import FARCY_COMMENT_START
+from .const import NUMBER_RE, FARCY_COMMENT_START
 
 IS_FARCY_COMMENT = FARCY_COMMENT_START.split('v')[0]
+
+
+def added_lines(patch):
+    """Return a mapping of added line numbers to the patch line numbers."""
+    added = {}
+    lineno = None
+    position = 0
+    for line in patch.split('\n'):
+        if line.startswith('@@'):
+            lineno = int(NUMBER_RE.match(line.split('+')[1]).group(1))
+        elif line.startswith(' '):
+            lineno += 1
+        elif line.startswith('+'):
+            added[lineno] = position
+            lineno += 1
+        elif line == "\ No newline at end of file":
+            continue
+        else:
+            assert line.startswith('-')
+        position += 1
+    return added
 
 
 def extract_issues(text):

--- a/farcy/helpers.py
+++ b/farcy/helpers.py
@@ -3,7 +3,7 @@
 
 from collections import defaultdict
 from datetime import timedelta, tzinfo
-from .const import NUMBER_RE, FARCY_COMMENT_START
+from .const import FARCY_COMMENT_START, NUMBER_RE
 
 IS_FARCY_COMMENT = FARCY_COMMENT_START.split('v')[0]
 

--- a/test/test_farcy.py
+++ b/test/test_farcy.py
@@ -13,17 +13,6 @@ MockResponse = namedtuple('MockResponse', ['content', 'status_code'])
 
 
 class FarcyTest(unittest.TestCase):
-    def test_added_lines(self):
-        self.assertEqual({}, Farcy.added_lines('@@+15'))
-        self.assertEqual({1: 1}, Farcy.added_lines('@@+1\n+wah'))
-        self.assertEqual({15: 1}, Farcy.added_lines('@@+15\n+wah'))
-        self.assertEqual({16: 2}, Farcy.added_lines('@@+15\n \n+wah'))
-        self.assertEqual({1: 2}, Farcy.added_lines('@@+1\n-\n+wah'))
-        self.assertEqual({15: 2}, Farcy.added_lines('@@+15\n-\n+wah'))
-        self.assertEqual({16: 3}, Farcy.added_lines('@@+15\n-\n \n+wah'))
-        self.assertEqual({1: 1, 15: 3},
-                         Farcy.added_lines('@@+1\n+wah\n@@+15\n+foo'))
-
     @patch('farcy.open', create=True)
     @patch('github3.authorize')
     @patch('getpass.getpass')

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -17,6 +17,32 @@ class MockComment(object):
         self.position = position
 
 
+class PatchFunctionTest(unittest.TestCase):
+    def test_added_lines(self):
+        self.assertEqual({}, helpers.added_lines('@@+15'))
+        self.assertEqual({1: 1}, helpers.added_lines('@@+1\n+wah'))
+        self.assertEqual({15: 1}, helpers.added_lines('@@+15\n+wah'))
+        self.assertEqual({16: 2}, helpers.added_lines('@@+15\n \n+wah'))
+        self.assertEqual({1: 2}, helpers.added_lines('@@+1\n-\n+wah'))
+        self.assertEqual({15: 2}, helpers.added_lines('@@+15\n-\n+wah'))
+        self.assertEqual({16: 3}, helpers.added_lines('@@+15\n-\n \n+wah'))
+        self.assertEqual({1: 1, 15: 3},
+                         helpers.added_lines('@@+1\n+wah\n@@+15\n+foo'))
+
+    def test_added_lines_works_with_github_no_newline_message(self):
+        patch = """@@ -0,0 +1,5 @@
++class SomeClass
++  def yo(some_unused_param)
++    puts 'hi'
++  end
++end
+\ No newline at end of file"""
+        try:
+            helpers.added_lines(patch)
+        except AssertionError:
+            self.fail('added_lines() raised AssertionError')
+
+
 class CommentFunctionTest(unittest.TestCase):
 
     """Tests common Farcy handler extension methods."""


### PR DESCRIPTION
GitHub adds a message to end of diffs if there was no newline at the end of a file:

```diff
@@ -0,0 +1,6 @@
+class SomeClass
+  def yo(some_unused_param)
+    # some really long comment some really long comment some really long comment some really long comment some really long comment
+    puts 'hi'
+  end
+end
\ No newline at end of file
```

This broke the `added_lines` method. I fixed this and added a test for this case. I also moved the added_lines method to the helpers file.