### PR TITLE
No longer crash when handling files in folders

### DIFF
--- a/farcy/__init__.py
+++ b/farcy/__init__.py
@@ -218,7 +218,7 @@ class Farcy(object):
 
         try:
             tmpdir = mkdtemp()
-            filepath = os.path.join(tmpdir, pfile.filename)
+            filepath = os.path.join(tmpdir, os.path.basename(pfile.filename))
             with open(filepath, 'wb') as fp:
                 fp.write(pfile.contents().decoded)
             for handler in handlers:


### PR DESCRIPTION
The name of `pfile.filename` is misleading as it also includes the full path of the file relative to the repository root. `open()` will raise a `FileNotFoundError` if we target a directory that does not exist.

This PR will only use the filename and strip out the path.