### PR TITLE
Limit comments

### DIFF
--- a/farcy/__init__.py
+++ b/farcy/__init__.py
@@ -40,8 +40,8 @@ from .const import (
     COMMIT_STATUS_FORMAT, FARCY_COMMENT_START, CONFIG_DIR)
 from .exceptions import FarcyException, HandlerException
 from .helpers import (
-    added_lines, filter_comments_from_farcy, issues_by_line, split_dict,
-    subtract_issues_by_line, UTC)
+    UTC, added_lines, filter_comments_from_farcy, issues_by_line, split_dict,
+    subtract_issues_by_line)
 
 
 class Farcy(object):

--- a/farcy/__init__.py
+++ b/farcy/__init__.py
@@ -308,7 +308,7 @@ class Farcy(object):
                           pr.number, file_issue_count,
                           's' if file_issue_count > 1 else '', pfile.filename))
 
-            if comments_added > self.pr_issue_report_limit:
+            if comments_added >= self.pr_issue_report_limit:
                 continue
 
             file_issues_to_comment = subtract_issues_by_line(

--- a/farcy/__init__.py
+++ b/farcy/__init__.py
@@ -218,7 +218,7 @@ class Farcy(object):
 
         try:
             tmpdir = mkdtemp()
-            filepath = os.path.join(tmpdir, pfile.filename)
+            filepath = os.path.join(tmpdir, os.path.basename(pfile.filename))
             with open(filepath, 'wb') as fp:
                 fp.write(pfile.contents().decoded)
             for handler in handlers:


### PR DESCRIPTION
This will limit the total number of comments that Farcy will add to a single PR, taking existing comments by Farcy into consideration. Currently defaulted to 128.

Includes an extra commit because branch is based on PR #39.

This PR fixes #35. 