### PR TITLE
Add short arguments for `limit-user` and `comments-per-pr`.

### DIFF
--- a/farcy/__init__.py
+++ b/farcy/__init__.py
@@ -46,8 +46,8 @@ from .const import (
     COMMIT_STATUS_FORMAT, FARCY_COMMENT_START, CONFIG_DIR)
 from .exceptions import FarcyException, HandlerException
 from .helpers import (
-    UTC, added_lines, filter_comments_from_farcy, issues_by_line, split_dict,
-    subtract_issues_by_line)
+    UTC, added_lines, filter_comments_from_farcy, issues_by_line,
+    process_user_list, split_dict, subtract_issues_by_line)
 
 
 class Farcy(object):
@@ -394,21 +394,6 @@ class Farcy(object):
         self.log.info('Monitoring {0}'.format(self.repo.html_url))
         for event in self.events():
             getattr(self, event.type)(event)
-
-
-def process_user_list(user_list):
-    """Return a normalized set from an expansion of the user list.
-
-    A single item in the input list can contain a comma separated list of items
-    which will be expanded in the output set.
-
-    Each item will be normalized to its lowercase format for comparison.
-
-    """
-    users = []
-    for item in user_list:
-        users.extend(x.strip().lower() for x in item.split(','))
-    return set(users) if users else None
 
 
 def main():

--- a/farcy/helpers.py
+++ b/farcy/helpers.py
@@ -62,6 +62,21 @@ def issues_by_line(comments, path):
     return by_line
 
 
+def process_user_list(user_list):
+    """Return a normalized set from an expansion of the user list.
+
+    A single item in the input list can contain a comma separated list of items
+    which will be expanded in the output set.
+
+    Each item will be normalized to its lowercase format for comparison.
+
+    """
+    users = []
+    for item in user_list:
+        users.extend(x.strip().lower() for x in item.split(','))
+    return set(users) if users else None
+
+
 def split_dict(data, keys):
     """Split a dict in a dict with keys `keys` and one with the rest."""
     with_keys = {}

--- a/test/test_farcy.py
+++ b/test/test_farcy.py
@@ -71,7 +71,6 @@ class FarcyTest(unittest.TestCase):
         mock_authorize.side_effect = TypeError
         self.assertRaises(TypeError, Farcy.get_session)
 
-
     @patch.object(GitHub, 'is_starred')
     @patch('farcy.open', create=True)
     @patch('farcy.os.path')

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -107,6 +107,22 @@ class PatchFunctionTest(unittest.TestCase):
             self.fail('added_lines() raised AssertionError')
 
 
+class ProcessUserListTest(unittest.TestCase):
+    def test_process_user_list__comma_separated(self):
+        self.assertEqual(set(['bar', 'baz', 'foo']),
+                         helpers.process_user_list(['foo, bar ,baz']))
+
+    def test_process_user_list__convert_to_lower(self):
+        self.assertEqual(set(['hello']), helpers.process_user_list(['HELLO']))
+
+    def test_process_user_list__empty_input(self):
+        self.assertEqual(None, helpers.process_user_list([]))
+
+    def test_process_user_list__separate_items(self):
+        self.assertEqual(set(['bar', 'foo']),
+                         helpers.process_user_list(['foo', 'bar']))
+
+
 class SplitDictTest(unittest.TestCase):
     def test_split_dict(self):
         test_dict = {1: 'a', 2: 'b', 3: 'c'}


### PR DESCRIPTION
Also:

* allow each user argument to be a comma separated list
* normalize user each argument by doing lowercase comparision
* return a user set rather than a list