### PR TITLE
Initial version config file support

### DIFF
--- a/farcy/__init__.py
+++ b/farcy/__init__.py
@@ -130,16 +130,14 @@ class Farcy(object):
         # Configure logging
         self.config = config
         self.log = logging.getLogger(__name__)
-        log_level = 'DEBUG' if config.debug else config.log_level
-        if log_level:
-            self.log.setLevel(int(getattr(logging, self.config.log_level)))
+        self.log.setLevel(config.log_level_int)
+        if config.log_level_int > logging.NOTSET:
             handler = logging.StreamHandler()
             handler.setFormatter(logging.Formatter(
                 '%(asctime)s %(levelname)8s %(message)s', '%Y/%m/%d %H:%M:%S'))
             self.log.addHandler(handler)
-            self.log.info('Logging enabled at level {0}'.format(log_level))
-        else:
-            self.log.setLevel(logging.NOTSET)
+            self.log.info('Logging enabled at level {0}'.format(
+                config.log_level))
 
         if config.start_event:
             self.start_time = None
@@ -396,7 +394,7 @@ def main():
         'debug': args['--debug'],
         'exclude_paths': args['--exclude-path'],
         'limit_users': args['--limit-user'] or config.limit_users,
-        'log_level': args['--logging'],
+        'log_level': args['--logging'] or config.log_level,
         'pr_issue_report_limit':
         args['--comments-per-pr'] or config.pr_issue_report_limit,
     })
@@ -404,9 +402,6 @@ def main():
     if config.repository is None:
         sys.stderr.write('No repository specified\n')
         return 2
-
-    print(config)
-    sys.exit()
 
     try:
         Farcy(config).run()

--- a/farcy/helpers.py
+++ b/farcy/helpers.py
@@ -181,7 +181,7 @@ class Config(object):
 
     @property
     def log_level_int(self):
-        """Int value of the log level"""
+        """Int value of the log level."""
         return getattr(logging, self.log_level)
 
     def user_whitelisted(self, user):

--- a/test/test_farcy.py
+++ b/test/test_farcy.py
@@ -3,6 +3,7 @@
 from __future__ import print_function
 from collections import namedtuple
 from farcy import Farcy, FarcyException, no_handler_debug_factory
+from farcy.helpers import Config
 from github3 import GitHub, GitHubError
 from io import IOBase
 from mock import MagicMock, call, patch
@@ -26,8 +27,11 @@ class FarcyTest(unittest.TestCase):
 
     @patch('farcy.Farcy.get_session')
     @patch('farcy.UpdateChecker')
-    def _farcy_instance(self, mock_get_session, mock_update_checker, **kwargs):
-        farcy = Farcy('dummy', 'dummy', **kwargs)
+    def _farcy_instance(self, mock_get_session, mock_update_checker,
+                        config=Config()):
+        if config.repository is None:
+            config.repository = 'dummy/dummy'
+        farcy = Farcy(config)
         self.assertTrue(mock_get_session.called)
         self.assertTrue(mock_update_checker.called)
         return farcy
@@ -44,7 +48,9 @@ class FarcyTest(unittest.TestCase):
 
     def test_compute_pfile_stats__excluded(self):
         stats = {'blacklisted_files': 10}
-        farcy = self._farcy_instance(exclude_paths=['tmp/*'])
+        config = Config()
+        config.exclude_paths = ['tmp/*']
+        farcy = self._farcy_instance(config=config)
         self.assertEqual(None, farcy._compute_pfile_stats(
             mockpfile(filename='tmp/foo'), stats))
         self.assertEqual({'blacklisted_files': 11}, stats)
@@ -70,7 +76,9 @@ class FarcyTest(unittest.TestCase):
 
     def test_compute_pfile_stats__removed(self):
         stats = {'deleted_files': 10}
-        farcy = self._farcy_instance(exclude_paths=['tmp/*'])
+        config = Config()
+        config.exclude_paths = ['tmp/*']
+        farcy = self._farcy_instance(config=config)
         self.assertEqual(None, farcy._compute_pfile_stats(
             mockpfile(filename='a/tmp/b', status='removed'), stats))
         self.assertEqual({'deleted_files': 11}, stats)

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -1,7 +1,9 @@
 """Farcy test file."""
 
 from __future__ import print_function
+import tempfile
 import unittest
+import farcy.exceptions as exceptions
 import farcy.helpers as helpers
 
 
@@ -15,6 +17,128 @@ class MockComment(object):
         self.body = body
         self.path = path
         self.position = position
+
+
+class ConfigTest(unittest.TestCase):
+    """Tests Config helper."""
+    def setUp(self):
+        self.config = helpers.Config()
+        self.tempdir = None
+
+    def test_dirty_checking(self):
+        self.config.debug = not self.config.debug
+        self.assertEqual(set(['debug']), self.config._dirty)
+
+    def test_not_mark_dirty_if_same_value(self):
+        self.config.debug = self.config.debug
+        self.assertEqual(set(), self.config._dirty)
+
+    def test_default_repo_from_config(self):
+        config = """
+        [default]
+        repository: appfolio/farcy
+        """
+
+        self._setup_config_file(config)
+        self.assertEqual('appfolio/farcy', self.config.repository)
+
+    def test_default_repo_from_config_raise_on_invalid(self):
+        config = """
+        [default]
+        repository: invalid_repo
+        """
+
+        with self.assertRaises(exceptions.FarcyException):
+            self._setup_config_file(config)
+
+    def test_config_file_values(self):
+        config = """
+        [default]
+        repository: appfolio/farcy
+        start_event: 10
+        debug: true
+        exclude_paths: node_modules,vendor
+        limit_users: balloob,bboe
+        log_level: DEBUG
+        pr_issue_report_limit: 100
+        """
+
+        self._setup_config_file(config)
+        self.assertEqual('appfolio/farcy', self.config.repository)
+        self.assertEqual(10, self.config.start_event)
+        self.assertEqual(True, self.config.debug)
+        self.assertEqual(['node_modules', 'vendor'], self.config.exclude_paths)
+        self.assertEqual(set(['balloob', 'bboe']), self.config.limit_users)
+        self.assertEqual('DEBUG', self.config.log_level)
+        self.assertEqual(100, self.config.pr_issue_report_limit)
+
+    def test_config_file_default_works(self):
+        config = """
+        [default]
+        start_event: 5
+        """
+
+        self._setup_config_file(config)
+        self.assertEqual(5, self.config.start_event)
+
+    def test_config_file_repo_specific_works(self):
+        config = """
+        [appfolio/farcy]
+        start_event: 5
+        """
+
+        self.config.repository = 'appfolio/farcy'
+        self._setup_config_file(config)
+        self.assertEqual(5, self.config.start_event)
+
+    def test_config_file_repo_specific_inherits_default(self):
+        config = """
+        [default]
+        limit_users: balloob
+
+        [appfolio/farcy]
+        start_event: 5
+        """
+
+        self.config.repository = 'appfolio/farcy'
+        self._setup_config_file(config)
+        self.assertEqual(set(['balloob']), self.config.limit_users)
+        self.assertEqual(5, self.config.start_event)
+
+    def test_config_file_only_sets_not_dirty(self):
+        config = """
+        [appfolio/farcy]
+        start_event: 5
+        """
+
+        self.config.start_event = 10
+        self._setup_config_file(config)
+        self.assertEqual(10, self.config.start_event)
+
+    def test_user_whitelisted_passes_if_not_set(self):
+        self.assertTrue(self.config.user_whitelisted('balloob'))
+
+    def test_user_whitelisted_works_if_set(self):
+        self.config.limit_users = ['bboe', 'balloob']
+        self.assertTrue(self.config.user_whitelisted('balloob'))
+        self.assertFalse(self.config.user_whitelisted('appfolio'))
+
+    def test_setting_repo(self):
+        repo = 'appfolio/farcy'
+        self.config.repository = repo
+        self.assertEqual(repo, self.config.repository)
+
+    def test_raise_if_invalid_repository(self):
+        with self.assertRaises(exceptions.FarcyException):
+            self.config.repository = 'invalid_repo'
+
+    def _setup_config_file(self, content):
+        with tempfile.NamedTemporaryFile() as fil:
+            fil.write(content.encode('utf-8'))
+            fil.flush()
+
+            self.config._config_path = fil.name
+            self.config.load_config_file()
 
 
 class CommentFunctionTest(unittest.TestCase):

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -132,6 +132,33 @@ start_event: 5
         with self.assertRaises(exceptions.FarcyException):
             self.config.repository = 'invalid_repo'
 
+    def test_raise_if_invalid_log_level(self):
+        with self.assertRaises(exceptions.FarcyException):
+            self.config.log_level = 'invalid_log_level'
+
+    def test_cant_change_log_level_if_debug(self):
+        self.config.debug = True
+        self.assertEqual('DEBUG', self.config.log_level)
+        self.config.log_level = 'WARNING'
+        self.assertEqual('DEBUG', self.config.log_level)
+
+    def test_setting_values_via_dict(self):
+        data = {
+            'repository': 'appfolio/farcy',
+            'start_event': 1000,
+            'debug': False,
+            'exclude_paths': ['npm_modules', 'vendor'],
+            'limit_users': ['balloob', 'bboe'],
+            'log_level': 'WARNING',
+            'pr_issue_report_limit': 100
+        }
+
+        self.config.load_dict(data)
+
+        for attr, value in data.items():
+            self.assertEqual(value, getattr(self.config, attr))
+
+
     def _setup_config_file(self, content):
         with tempfile.NamedTemporaryFile() as fil:
             fil.write(content.encode('utf-8'))

--- a/test/test_helpers.py
+++ b/test/test_helpers.py
@@ -35,8 +35,8 @@ class ConfigTest(unittest.TestCase):
 
     def test_default_repo_from_config(self):
         config = """
-        [default]
-        repository: appfolio/farcy
+[default]
+repository: appfolio/farcy
         """
 
         self._setup_config_file(config)
@@ -44,8 +44,8 @@ class ConfigTest(unittest.TestCase):
 
     def test_default_repo_from_config_raise_on_invalid(self):
         config = """
-        [default]
-        repository: invalid_repo
+[default]
+repository: invalid_repo
         """
 
         with self.assertRaises(exceptions.FarcyException):
@@ -53,14 +53,14 @@ class ConfigTest(unittest.TestCase):
 
     def test_config_file_values(self):
         config = """
-        [default]
-        repository: appfolio/farcy
-        start_event: 10
-        debug: true
-        exclude_paths: node_modules,vendor
-        limit_users: balloob,bboe
-        log_level: DEBUG
-        pr_issue_report_limit: 100
+[default]
+repository: appfolio/farcy
+start_event: 10
+debug: true
+exclude_paths: node_modules,vendor
+limit_users: balloob,bboe
+log_level: DEBUG
+pr_issue_report_limit: 100
         """
 
         self._setup_config_file(config)
@@ -74,8 +74,8 @@ class ConfigTest(unittest.TestCase):
 
     def test_config_file_default_works(self):
         config = """
-        [default]
-        start_event: 5
+[default]
+start_event: 5
         """
 
         self._setup_config_file(config)
@@ -83,8 +83,8 @@ class ConfigTest(unittest.TestCase):
 
     def test_config_file_repo_specific_works(self):
         config = """
-        [appfolio/farcy]
-        start_event: 5
+[appfolio/farcy]
+start_event: 5
         """
 
         self.config.repository = 'appfolio/farcy'
@@ -93,11 +93,11 @@ class ConfigTest(unittest.TestCase):
 
     def test_config_file_repo_specific_inherits_default(self):
         config = """
-        [default]
-        limit_users: balloob
+[default]
+limit_users: balloob
 
-        [appfolio/farcy]
-        start_event: 5
+[appfolio/farcy]
+start_event: 5
         """
 
         self.config.repository = 'appfolio/farcy'
@@ -107,8 +107,8 @@ class ConfigTest(unittest.TestCase):
 
     def test_config_file_only_sets_not_dirty(self):
         config = """
-        [appfolio/farcy]
-        start_event: 5
+[appfolio/farcy]
+start_event: 5
         """
 
         self.config.start_event = 10


### PR DESCRIPTION
This is an initial version to add support for configuring Farcy via configuration files. It supports a structure similar to [praw](http://praw.readthedocs.org/en/latest/pages/configuration_files.html): a default configuration section and a section per repository.

 - Configuration priority is: command line arguments > repo specific section > default section. They overwrite one another, they will not be merged.
 - It will look for a configuration file at `~/.config/farcy/farcy.conf`.
 - The default section supports 1 extra parameter: `repository`. This will be used if no repository given as command line argument.
 - Debug expects a true-ish value: `true` or `1`

Example:

```conf
[default]
repository: appfolio/farcy
limit_users: balloob
exclude_paths: node_modules, vendor, db

[appfolio/farcy]
limit_users: balloob, bboe
start_event: 100
debug: 1
exclude_paths: node_modules, some_other_path
limit_users: balloob, bboe
log_level: DEBUG
pr_issue_report_limit: 20
```