### PR TITLE
Added pending commit status on start handle_pr

### DIFF
--- a/farcy/__init__.py
+++ b/farcy/__init__.py
@@ -288,8 +288,11 @@ class Farcy(object):
             return
         self.log.info('Handling PR#{0} by {1}'
                       .format(pr.number, pr.user.login))
-
         sha = list(pr.commits())[-1].sha
+        if not self.debug:
+            self.repo.create_status(
+                sha, 'pending', context=VERSION_STR,
+                description='started investigation')
         exception = False
         existing_comments = list(filter_comments_from_farcy(
             pr.review_comments()))


### PR DESCRIPTION
This will add a pending commit status when Farcy is handling a PR so the user can see Farcy is running.

In the future we will probably want to have our event handlers set up a pending state right away. But to do this we would have to have to convert to a process queue instead of handling PRs synchronosouly  when events come in.