### PR TITLE
Initial Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM phusion/passenger-full
+
+# Set correct environment variables.
+ENV HOME /root
+WORKDIR /home/app
+VOLUME /config
+
+COPY . /home/app
+
+# Farcy + Python linters
+RUN mkdir /root/.config && \
+    ln -sf /config /root/.config/farcy && \
+    curl https://bootstrap.pypa.io/get-pip.py | python3 && \
+    apt-get update && \
+    apt-get install -y python3-dev libffi-dev && \
+    pip3 install .[python] && \
+    apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# ESLint
+RUN npm install eslint babel-eslint eslint-plugin-react
+
+# Rubocop
+RUN gem install rubocop
+
+CMD ["farcy"]

--- a/README.rst
+++ b/README.rst
@@ -61,6 +61,20 @@ required. Install via:
     $ npm install -g jsxhint
 
 
+Docker
+------
+Farcy can be run from a Docker container. Run it in interactive mode from the desktop to setup the GitHub credentials. This has to be done once and can be shared between containers.
+
+.. code-block:: bash
+
+    $ docker run -t -i --name="farcy" -v /path/to/local/farcy/config:/config appfolio/farcy
+
+After the initials are setup, you can run it in the background.
+
+.. code-block:: bash
+
+    $ docker run -d --name="farcy" -v /path/to/local/farcy/config:/config appfolio/farcy
+
 Copyright and license
 ---------------------
 


### PR DESCRIPTION
This adds support for Docker.

Right now, if the config does not point at a repo, it will never ask for GitHub credentials. We should probably switch the check for no repository with GitHub credentials. Also we should add a readme section about configuration files 