### PR TITLE
accept-more-versioning-formats

### DIFF
--- a/farcy/handlers.py
+++ b/farcy/handlers.py
@@ -109,6 +109,10 @@ class ExtHandler(object):
         try:
             version = (check_output([self.BINARY, '--version'], stderr=STDOUT)
                        .decode('utf-8'))
+
+            # Remove all non 'versioning' characters from the string
+            version = re.search('(\d+\.*)+', version).group(0)
+
         except OSError as exc:
             if exc.errno == 2:
                 raise HandlerNotReady('{0} is not installed.'


### PR DESCRIPTION
Some programs output more than ``0.24.1`` when asked for ``--version``.
``yardstick --version`` outputs ``yardstick 0.9.9``
``git --version`` outputs ``git version 1.9.1``

This PR uses regex to parse the version number.

I wasn't sure if I should test this or, as there is no specific test for ``assert_usable``, and I suppose that``assert_usable`` is implicitly tested by all other handler tests, since it's part of the their class initialization.