### PR TITLE
Ignore "hidden" comments.

### DIFF
--- a/farcy/__init__.py
+++ b/farcy/__init__.py
@@ -316,6 +316,7 @@ class Farcy(object):
                 pfile, pr, sha, handle_data) or exception
 
         handle_data['stats']['issues'] += error_tracker.new_issue_count
+        handle_data['stats']['hidden'] += error_tracker.hidden_issue_count
 
         # Log the statistics for the PR
         for key, count in sorted(handle_data['stats'].items()):

--- a/farcy/objects.py
+++ b/farcy/objects.py
@@ -210,6 +210,7 @@ class ErrorTracker(object):
         self.by_file = {}
         self.github_message_count = 0
         self.group_threshold = group_threshold
+        self.hidden_issue_count = 0
         self.new_issue_count = 0
         self.from_github_comments(github_comments)
 
@@ -226,6 +227,9 @@ class ErrorTracker(object):
         """Populate the error tracker with Farcy comments from github."""
         for comment in comments:
             if not comment.body.startswith(self.FARCY_PREFIX):
+                continue
+            if comment.position == 0:
+                self.hidden_issue_count += 1
                 continue
             self.github_message_count += 1
             for issue in comment.body.split('\n')[1:]:

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,9 @@ setup(name=PACKAGE_NAME,
       license='Simplified BSD License',
       long_description=README,
       packages=[PACKAGE_NAME],
-      tests_require=['mock >= 1.0.1'],
+      tests_require=['mock >= 1.0.1',
+                     # https://bugs.launchpad.net/pbr/+bug/1493735
+                     'pbr < 1.7.0'],
       test_suite='test',
       url='https://github.com/appfolio/farcy',
       version=VERSION)

--- a/test/helper.py
+++ b/test/helper.py
@@ -1,5 +1,6 @@
 """Farcy test helpers."""
 
+
 class Struct(object):
     def __init__(self, iterable=None, **attrs):
         self.__dict__.update(attrs)

--- a/test/test_objects.py
+++ b/test/test_objects.py
@@ -183,6 +183,7 @@ class ErrorMessageTest(unittest.TestCase):
     def test_track_group__return_value(self):
         self.assertEqual(self.message, self.message.track_group(16, 2))
 
+
 class ErrorTrackerTest(unittest.TestCase):
     def setUp(self):
         self.tracker = objects.ErrorTracker([], 2)
@@ -194,7 +195,7 @@ class ErrorTrackerTest(unittest.TestCase):
     def test_no_issues(self):
         self.assertEqual([], list(self.tracker.errors('DummyFile')))
 
-        comment = Struct(body='Regular comment', path='DummyFile',position=16)
+        comment = Struct(body='Regular comment', path='DummyFile', position=16)
         self.tracker.from_github_comments([comment])
 
         self.assertEqual(0, self.tracker.github_message_count)
@@ -239,18 +240,6 @@ class ErrorTrackerTest(unittest.TestCase):
         self.assertEqual(1, self.tracker.github_message_count)
         self.assertEqual(2, self.tracker.new_issue_count)
         self.assertEqual([(17, ['Non MatchingError'])],
-                         list(self.tracker.errors('DummyFile')))
-
-    def test_one_unique_issue__same_line(self):
-        comment = Struct(body='_[farcy \n* MatchingError', path='DummyFile',
-                         position=16)
-        self.tracker.from_github_comments([comment])
-        self.tracker.track('MatchingError', 'DummyFile', 16)
-        self.tracker.track('Non MatchingError', 'DummyFile', 16)
-
-        self.assertEqual(1, self.tracker.github_message_count)
-        self.assertEqual(2, self.tracker.new_issue_count)
-        self.assertEqual([(16, ['Non MatchingError'])],
                          list(self.tracker.errors('DummyFile')))
 
     def test_one_unique_issue__same_line(self):

--- a/test/test_objects.py
+++ b/test/test_objects.py
@@ -199,6 +199,7 @@ class ErrorTrackerTest(unittest.TestCase):
         self.tracker.from_github_comments([comment])
 
         self.assertEqual(0, self.tracker.github_message_count)
+        self.assertEqual(0, self.tracker.hidden_issue_count)
         self.assertEqual(0, self.tracker.new_issue_count)
         self.assertEqual([], list(self.tracker.errors('DummyFile')))
 
@@ -211,6 +212,7 @@ class ErrorTrackerTest(unittest.TestCase):
         self.tracker.track('MatchingError', 'DummyFile', 19)
 
         self.assertEqual(1, self.tracker.github_message_count)
+        self.assertEqual(0, self.tracker.hidden_issue_count)
         self.assertEqual(3, self.tracker.new_issue_count)
         self.assertEqual([], list(self.tracker.errors('DummyFile')))
 
@@ -222,11 +224,13 @@ class ErrorTrackerTest(unittest.TestCase):
         self.tracker.from_github_comments([comment])
 
         self.assertEqual(1, self.tracker.github_message_count)
+        self.assertEqual(0, self.tracker.hidden_issue_count)
         self.assertEqual(0, self.tracker.new_issue_count)
         self.assertEqual([], list(self.tracker.errors('DummyFile')))
 
         self.tracker.track('MatchingError', 'DummyFile', 16)
         self.assertEqual(1, self.tracker.github_message_count)
+        self.assertEqual(0, self.tracker.hidden_issue_count)
         self.assertEqual(1, self.tracker.new_issue_count)
         self.assertEqual([], list(self.tracker.errors('DummyFile')))
 
@@ -253,3 +257,13 @@ class ErrorTrackerTest(unittest.TestCase):
         self.assertEqual(2, self.tracker.new_issue_count)
         self.assertEqual([(16, ['Non MatchingError'])],
                          list(self.tracker.errors('DummyFile')))
+
+    def test_only_hidden_issues(self):
+        comment = Struct(body='_[farcy \n* MatchingError', path='DummyFile',
+                         position=0)
+        self.tracker.from_github_comments([comment])
+
+        self.assertEqual(0, self.tracker.github_message_count)
+        self.assertEqual(1, self.tracker.hidden_issue_count)
+        self.assertEqual(0, self.tracker.new_issue_count)
+        self.assertEqual([], list(self.tracker.errors('DummyFile')))


### PR DESCRIPTION
Hidden comments are comments that github considers to be on "outdated
diffs". In the event that farcy has reached its self-imposed comment limit, it
would no longer make new comments making it impossible from the pull request
view to receive feedback on new issues. Because those comments are hidden on
page load, ignoring them in the comment count _should_ avoid the breaking the
pull request view (the reason why #35 was filed and subsequently resolved).

In the event we break pull request views again, we can use the information
about hidden comments to delete as many as needed.

Resolve #78.