### PR TITLE
Add fast_finish to travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ python:
   - pypy
   - pypy3
 matrix:
+  fast_finish: true
   allow_failures:
   - python: nightly
   - python: pypy


### PR DESCRIPTION
This will make Travis report the final status as soon as no other builds can have any impact on the final status. So if 1 build fails it will already report that the overall status is failed, if there are only jobs left that we allow failures of, it will mark the PR as a success.

[More info in their blog post](https://blog.travis-ci.com/2013-11-27-fast-finishing-builds/)