### PR TITLE
Handle github3.py ServerError around event_loop.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 # Unreleased
+* __[BUGIFX]__ Handle github3.exceptions.ServerErrors in the event loop.
 * __[CHANGE]__ Drop python 3.2 support (not easily supported by coveralls and
   is minimally used:
   https://github.com/praw-dev/praw/pull/532#issuecomment-142110977).

--- a/farcy/__init__.py
+++ b/farcy/__init__.py
@@ -33,6 +33,7 @@ from collections import Counter, defaultdict
 from datetime import datetime
 from docopt import docopt
 from fnmatch import fnmatch
+from github3.exceptions import ServerError
 from random import choice
 from requests import ConnectionError
 from shutil import rmtree
@@ -255,8 +256,8 @@ class Farcy(object):
             itr = self.repo.events(etag=etag)
             try:
                 newest_id = self._event_loop(itr, events)
-            except ConnectionError as exc:
-                self.log.warning('ConnectionError {0}'.format(exc))
+            except (ConnectionError, ServerError) as exc:
+                self.log.warning('Error in event loop: {0}'.format(exc))
                 sleep_time = 1
                 continue
 


### PR DESCRIPTION
This fix resolves #87, and a 502 error I received in the same section of code.