### PR TITLE
Throw Useful SCSS-Lint Exception

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 # Unreleased
+* __[FEATURE]__ Provide an SCSS-Lint handler for css and scss .css and .scss files (well tested).
 * __[BUGIFX]__ Handle github3.exceptions.ServerErrors in the event loop.
 * __[BUGFIX]__ Add catch-all for exceptions that could occur when handling a
   PullRequest or Push event.

--- a/farcy/handlers.py
+++ b/farcy/handlers.py
@@ -260,6 +260,12 @@ class SCSSLint(ExtHandler):
         if not data.values():
             return retval
         for offense in next(iter(data.values())):
+            if 'linter' not in offense:
+                exception_message = (
+                    "Error occurred during linting: {reason} "
+                    "(line {line}, column {column})"
+                ).format(**offense)
+                raise HandlerException(exception_message)
             retval[offense['line']].append(
                 '{linter}: {reason}'.format(**offense)
             )

--- a/test/examples/linting_exception.scss
+++ b/test/examples/linting_exception.scss
@@ -1,0 +1,1 @@
+.broken-class {

--- a/test/test_handlers.py
+++ b/test/test_handlers.py
@@ -1,9 +1,10 @@
 """Farcy handlers test file."""
 
 from __future__ import print_function
-import farcy.handlers
 import os
 import unittest
+from farcy.exceptions import HandlerException
+import farcy.handlers
 
 
 class ExtHandlerTest(unittest.TestCase):
@@ -178,7 +179,6 @@ class RubocopTest(FarcyTest):
 
 
 class SCSSLintTest(FarcyTest):
-
     """Tests for the SCSSLint Handler."""
 
     def setUp(self):
@@ -200,3 +200,13 @@ class SCSSLintTest(FarcyTest):
         self.assertEqual({1: [('SelectorFormat: Selector `test_class` '
                                'should be written in lowercase with hyphens')]},
                          errors)
+
+    def test_linting_exception(self):
+        """We should raise an error with useful information if linting fails."""
+        try:
+            self.linter.process(self.path('linting_exception.scss'))
+        except HandlerException as e:
+            self.assertEqual('Error occurred during linting: Syntax Error: '
+                             'Invalid CSS after ".broken-class '
+                             '{": expected "}", was "" (line 2, column 1)',
+                             e.message)

--- a/test/test_handlers.py
+++ b/test/test_handlers.py
@@ -205,8 +205,8 @@ class SCSSLintTest(FarcyTest):
         """We should raise an error with useful information if linting fails."""
         try:
             self.linter.process(self.path('linting_exception.scss'))
-        except HandlerException as e:
+        except HandlerException as exc:
             self.assertEqual('Error occurred during linting: Syntax Error: '
                              'Invalid CSS after ".broken-class '
                              '{": expected "}", was "" (line 2, column 1)',
-                             e.message)
+                             '{0}'.format(exc))


### PR DESCRIPTION
- Adds a useful error message when SCSS-Lint throws an exception while linting. Closes #99
- Also, adds SCSS-Lint to the Unreleased section of `CHANGES.md`