### PR TITLE
Fix Flake8 issues

### DIFF
--- a/farcy/__init__.py
+++ b/farcy/__init__.py
@@ -303,8 +303,8 @@ class Farcy(object):
 
     def handle_pr(self, pr, force=False):
         """Provide code review on pull request."""
-        failure = not force and (self._fail_whitelist(pr)
-                                 or self._fail_closed(pr))
+        failure = not force and (self._fail_whitelist(pr) or
+                                 self._fail_closed(pr))
         if failure:
             self.log.debug(failure)
             return

--- a/farcy/objects.py
+++ b/farcy/objects.py
@@ -47,8 +47,8 @@ class Config(object):
 
     def __repr__(self):
         """String representation of the config."""
-        keys = sorted(x for x in self.__dict__ if not x.startswith('_')
-                      and x != 'repository')
+        keys = sorted(x for x in self.__dict__ if not x.startswith('_') and
+                      x != 'repository')
         arg_fmt = ', '.join(['{0}={1!r}'.format(key, getattr(self, key))
                              for key in keys])
         return 'Config({0!r}, {1})'.format(self.repository, arg_fmt)
@@ -256,6 +256,14 @@ class UTC(tzinfo):
 
     """
 
-    dst = lambda x, y: timedelta(0)
-    tzname = lambda x, y: 'UTC'
-    utcoffset = lambda x, y: timedelta(0)
+    def dst(self, dt):
+        """Return the daylight saving time adjustment."""
+        return timedelta(0)
+
+    def tzname(self, dt):
+        """Name of the timezone."""
+        return 'UTC'
+
+    def utcoffset(self, dt):
+        """Offset from UTC time."""
+        return timedelta(0)


### PR DESCRIPTION
One of the Flake8 dependencies became more strict. This PR fixes the new issues so CI passes.

```
farcy/__init__.py:307:34: W503 line break before binary operator
farcy/objects.py:51:23: W503 line break before binary operator
farcy/objects.py:259:5: E731 do not assign a lambda expression, use a def
farcy/objects.py:260:5: E731 do not assign a lambda expression, use a def
farcy/objects.py:261:5: E731 do not assign a lambda expression, use a def
```