### PR TITLE
ESLint to handle invalid JS syntax

### DIFF
--- a/farcy/handlers.py
+++ b/farcy/handlers.py
@@ -158,11 +158,14 @@ class ESLint(ExtHandler):
         if config_path:
             command += ['--config', config_path]
 
-        data = json.loads(self.execute(command + [filename]))
+        data = json.loads(self.execute(command + [filename]))[0]
         retval = defaultdict(list)
-        for offense in data[0]['messages']:
-            retval[offense['line']].append(
-                '{message} ({ruleId})'.format(**offense))
+
+        for offense in data['messages']:
+            message = offense['message']
+            if offense.get('ruleId'):
+                message += ' ({})'.format(offense['ruleId'])
+            retval[offense['line']].append(message)
         return retval
 
     def version_callback(self, version):

--- a/test/examples/invalid_syntax.js
+++ b/test/examples/invalid_syntax.js
@@ -1,0 +1,4 @@
+
+module.exports = function hello(name) {
+  return 'Hello ' name;
+}

--- a/test/test_handlers.py
+++ b/test/test_handlers.py
@@ -110,6 +110,12 @@ class ESLintTest(FarcyTest):
         self.assertEqual({3: ['Unexpected console statement. (no-console)']},
                          errors)
 
+    def test_invalid_syntax(self):
+        """Test an error is returned for correct line when syntax error."""
+        errors = self.linter.process(self.path('invalid_syntax.js'))
+        self.assertEqual({3: ['Parsing error: Unexpected token name']},
+                         errors)
+
 
 class Flake8Test(FarcyTest):
 


### PR DESCRIPTION
ESLint will not have a ruleId as part of the message when it encounters invalid syntax. With this PR, the ESLint handler will no longer fail with an exception of being unable to find key 'ruleId' but print the correct error message.